### PR TITLE
fixes the bug that causes the  ball to pass through platform at start

### DIFF
--- a/game.js
+++ b/game.js
@@ -118,7 +118,7 @@ Ball.prototype.move = function(){
         
         //TODO: Check for a hit with platform
     }
-    if (!this.dX || !this.dY) this.calculatedXdY();
+    if ((this.dY == null) || (this.dY == null)) this.calculatedXdY();
     
     this.oldX = this.x;
     this.oldY = this.y;    

--- a/gamestarter.js
+++ b/gamestarter.js
@@ -3,7 +3,7 @@
 var port = 1337;
 var portP1 = 1338;
 var portP2 = 1339;
-var ip = "192.168.0.102";
+var ip = "localhost";
 var WS_START = "ws://";
 var connectMsg = "connected";
 


### PR DESCRIPTION
 calculateXdY() was fired even though dX and dY. dY was set to 0, so the new value from calculatedXdY was written over the recently new value for dX incorrectly, resulting in a reset of dX. 

Checking if dX and dY is null instead !dX !dY did the trick.
